### PR TITLE
aud - (Qt) Refactor queue-manager to match Audacious:

### DIFF
--- a/src/libfauxdqt/queue-manager-qt.cc
+++ b/src/libfauxdqt/queue-manager-qt.cc
@@ -1,6 +1,6 @@
 /*
- * queue-manager.cc
- * Copyright 2014 William Pitcock, John Lindgren
+ * queue-manager-qt.cc
+ * Copyright 2014 Ariadne Conill, John Lindgren
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -19,44 +19,67 @@
 
 #include "libfauxdqt-internal.h"
 #include "libfauxdqt.h"
+#include "treeview.h"
 
 #include <QAbstractListModel>
-#include <QDialog>
-#include <QDialogButtonBox>
-#include <QPushButton>
 #include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QKeyEvent>
-#include <QTreeView>
+#include <QPushButton>
 #include <QVBoxLayout>
-#include <QPointer>
 
 #include <libfauxdcore/audstrings.h>
-#include <libfauxdcore/playlist.h>
 #include <libfauxdcore/hook.h>
 #include <libfauxdcore/i18n.h>
+#include <libfauxdcore/playlist.h>
 
-/*
- * TODO:
- *     - shifting of selection entries
- */
+namespace audqt
+{
 
-namespace audqt {
+static inline QPoint position(QDropEvent * event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return event->position ().toPoint ();
+#else
+    return event->pos ();
+#endif
+}
 
 class QueueManagerModel : public QAbstractListModel
 {
 public:
+    enum
+    {
+        ColumnEntry,
+        ColumnTitle,
+        NColumns
+    };
+
     void update (QItemSelectionModel * sel);
     void selectionChanged (const QItemSelection & selected, const QItemSelection & deselected);
 
 protected:
-    int rowCount(const QModelIndex & parent) const
+    int rowCount(const QModelIndex & parent) const override
     {
         return parent.isValid () ? 0 : m_rows;
     }
 
-    int columnCount (const QModelIndex & parent) const { return 2; }
-    QVariant data (const QModelIndex & index, int role) const;
+    int columnCount (const QModelIndex &) const override { return NColumns; }
+
+    Qt::DropActions supportedDropActions () const override { return Qt::MoveAction; }
+    Qt::ItemFlags flags (const QModelIndex & index) const
+    {
+        if (index.isValid ())
+            return Qt::ItemIsSelectable | Qt::ItemIsDragEnabled |
+                   Qt::ItemIsEnabled;
+        else
+            return Qt::ItemIsSelectable | Qt::ItemIsDropEnabled |
+                   Qt::ItemIsEnabled;
+    }
+
+    QVariant data (const QModelIndex & index, int role) const override;
+    QVariant headerData (int section, Qt::Orientation orientation, int role)
+            const override;
 
 private:
     int m_rows = 0;
@@ -70,15 +93,37 @@ QVariant QueueManagerModel::data (const QModelIndex & index, int role) const
         int list = aud_playlist_get_active ();
         int entry = aud_playlist_queue_get_entry (list, index.row ());
 
-        if (index.column () == 0)
+        if (index.column () == ColumnEntry)
             return entry + 1;
-        else
+        else if (index.column () == ColumnTitle)
         {
             Tuple tuple = aud_playlist_entry_get_tuple (list, entry, Playlist::NoWait);
             return QString ((const char *) tuple.get_str (Tuple::FormattedTitle));
         }
     }
-    else if (role == Qt::TextAlignmentRole && index.column () == 0)
+    else if (role == Qt::TextAlignmentRole && index.column () == ColumnEntry)
+        return Qt::AlignRight;
+
+    return QVariant ();
+}
+
+QVariant QueueManagerModel::headerData (int section, Qt::Orientation orientation,
+        int role) const
+{
+    if (orientation != Qt::Horizontal)
+        return QVariant ();
+
+    if (role == Qt::DisplayRole)
+    {
+        switch (section)
+        {
+            case ColumnEntry:
+                return QString ("#");
+            case ColumnTitle:
+                return QString (_("Title"));
+        }
+    }
+    else if (role == Qt::TextAlignmentRole && section == ColumnEntry)
         return Qt::AlignRight;
 
     return QVariant ();
@@ -112,7 +157,7 @@ void QueueManagerModel::update (QItemSelectionModel * sel)
         emit dataChanged (topLeft, bottomRight);
     }
 
-    for (int i = 0; i < rows; i ++)
+    for (int i = 0; i < rows; i++)
     {
         if (aud_playlist_entry_get_selected (list, aud_playlist_queue_get_entry (list, i)))
             sel->select (createIndex (i, 0), sel->Select | sel->Rows);
@@ -124,7 +169,7 @@ void QueueManagerModel::update (QItemSelectionModel * sel)
 }
 
 void QueueManagerModel::selectionChanged (const QItemSelection & selected,
- const QItemSelection & deselected)
+        const QItemSelection & deselected)
 {
     if (m_in_update)
         return;
@@ -133,11 +178,129 @@ void QueueManagerModel::selectionChanged (const QItemSelection & selected,
 
     for (auto & index : selected.indexes ())
         aud_playlist_entry_set_selected (list,
-         aud_playlist_queue_get_entry (list, index.row ()), true);
+                aud_playlist_queue_get_entry (list, index.row ()), true);
 
     for (auto & index : deselected.indexes ())
         aud_playlist_entry_set_selected (list,
-         aud_playlist_queue_get_entry (list, index.row ()), false);
+                aud_playlist_queue_get_entry (list, index.row ()), false);
+}
+
+class QueueManagerView : public audqt::TreeView
+{
+public:
+    QueueManagerView ();
+    void removeSelected ();
+    void update () { m_model.update (selectionModel ()); }
+
+protected:
+    void dropEvent (QDropEvent * event) override;
+    void keyPressEvent (QKeyEvent * event) override;
+
+private:
+    QueueManagerModel m_model;
+
+    void shiftRows (int before);
+
+    const HookReceiver<QueueManagerView>
+            update_hook{"playlist update", this, & QueueManagerView::update},
+            activate_hook{"playlist activate", this, & QueueManagerView::update};
+};
+
+QueueManagerView::QueueManagerView ()
+{
+    setAllColumnsShowFocus (true);
+    setDragDropMode (InternalMove);
+    setFrameShape (QFrame::NoFrame);
+    setIndentation (0);
+    setModel (&m_model);
+    setSelectionMode (ExtendedSelection);
+
+    auto hdr = header ();
+    hdr->setSectionResizeMode (QueueManagerModel::ColumnEntry,
+            QHeaderView::Interactive);
+    hdr->resizeSection(QueueManagerModel::ColumnEntry, audqt::to_native_dpi (50));
+
+    connect(selectionModel (), &QItemSelectionModel::selectionChanged, &m_model,
+            &QueueManagerModel::selectionChanged);
+}
+
+void QueueManagerView::removeSelected ()
+{
+    int list = aud_playlist_get_active ();
+    int count = aud_playlist_queue_count (list);
+
+    for (int i = 0; i < count;)
+    {
+        int entry = aud_playlist_queue_get_entry (list, i);
+        if (aud_playlist_entry_get_selected (list, entry))
+        {
+            aud_playlist_queue_delete (list, i, 1);
+            aud_playlist_entry_set_selected (list, entry, false);
+            count--;
+        }
+        else
+            i++;
+    }
+}
+
+void QueueManagerView::dropEvent (QDropEvent * event)
+{
+    if (event->source () != this || event->proposedAction () != Qt::MoveAction)
+        return;
+
+    int from = currentIndex ().row ();
+    if (from < 0)
+        return;
+
+    int to;
+    switch (dropIndicatorPosition ())
+    {
+        case AboveItem:
+            to = indexAt(position (event)).row ();
+            break;
+        case BelowItem:
+            to = indexAt(position (event)).row() + 1;
+            break;
+        default:
+            return;
+    }
+
+    shiftRows (to);
+    event->acceptProposedAction ();
+
+}
+
+void QueueManagerView::keyPressEvent (QKeyEvent * event)
+{
+    if (event->key () == Qt::Key_Delete)
+        removeSelected ();
+
+    QTreeView::keyPressEvent (event);
+}
+
+void QueueManagerView::shiftRows (int before)
+{
+    Index<int> shift;
+    int list = aud_playlist_get_active ();
+    int count = aud_playlist_queue_count (list);
+
+    for (int i = 0; i < count; i++)
+    {
+        int entry = aud_playlist_queue_get_entry (list, i);
+
+        if (aud_playlist_entry_get_selected (list, entry))
+        {
+            shift.append (entry);
+
+            if (i < before)
+                before--;
+        }
+    }
+
+    aud_playlist_queue_delete_selected (list);
+
+    for (int i = 0; i < shift.len (); i++)
+        aud_playlist_queue_insert (list, before + i, shift[i]);
 }
 
 class QueueManager : public QWidget
@@ -147,86 +310,45 @@ public:
 
     QSize sizeHint () const override
     {
-        return {4 * sizes.OneInch, 3 * sizes.OneInch};
+        return {3 * sizes.OneInch, 2 * sizes.OneInch};
     }
-
-protected:
-    void keyPressEvent(QKeyEvent * event) override;
 
 private:
-    QTreeView m_treeview;
+    QueueManagerView m_view;
     QPushButton m_btn_unqueue;
-    QueueManagerModel m_model;
-
-    void removeSelected ();
-    void update () { m_model.update (m_treeview.selectionModel ()); }
-
-    const HookReceiver<QueueManager> update_hook{"playlist update", this,
-                                                 & QueueManager::update},
-        activate_hook{"playlist activate", this, & QueueManager::update};
+    QPushButton m_btn_close;
 };
 
-void QueueManager::keyPressEvent(QKeyEvent * event)
+QueueManager::QueueManager (QWidget * parent) : QWidget (parent)
 {
-    if (event->key() == Qt::Key_Delete)
-        removeSelected();
+    setWindowRole("queue-manager");
 
-    QWidget::keyPressEvent(event);
-}
-
-QueueManager::QueueManager(QWidget * parent) : QWidget(parent)
-{
-    setWindowRole ("queue-manager");
     m_btn_unqueue.setText (translate_str (N_("_Unqueue")));
+    connect(&m_btn_unqueue, &QAbstractButton::clicked, &m_view,
+            &QueueManagerView::removeSelected);
 
-    connect (& m_btn_unqueue, & QAbstractButton::clicked, this, & QueueManager::removeSelected);
+    m_btn_close.setText (translate_str (N_("_Close")));
+    connect (&m_btn_close, & QPushButton::clicked, [] () {
+        audqt::queue_manager_hide ();
+    });
 
-    auto hbox = audqt::make_hbox(nullptr);
-    hbox->setContentsMargins(audqt::margins.TwoPt);
-    hbox->addStretch(1);
-    hbox->addWidget(&m_btn_unqueue);
+    auto hbox = audqt::make_hbox (nullptr);
+    hbox->setContentsMargins (audqt::margins.TwoPt);
+    hbox->addStretch (1);
+    hbox->addWidget (&m_btn_unqueue);
+    hbox->addWidget (&m_btn_close);
 
     auto layout = make_vbox (this, 0);
-    layout->addWidget (& m_treeview);
+    layout->addWidget (&m_view);
     layout->addLayout (hbox);
 
-    m_treeview.setAllColumnsShowFocus(true);
-    m_treeview.setIndentation (0);
-    m_treeview.setModel (& m_model);
-    m_treeview.setSelectionMode (QAbstractItemView::ExtendedSelection);
-    m_treeview.setHeaderHidden (true);
-
-    update ();
-
-    connect (m_treeview.selectionModel (),
-     & QItemSelectionModel::selectionChanged, & m_model,
-     & QueueManagerModel::selectionChanged);
-}
-
-void QueueManager::removeSelected ()
-{
-    int list = aud_playlist_get_active ();
-    int count = aud_playlist_queue_count (list);
-
-    for (int i = 0; i < count; )
-    {
-        int entry = aud_playlist_queue_get_entry (list, i);
-
-        if (aud_playlist_entry_get_selected (list, entry))
-        {
-            aud_playlist_queue_delete (list, i, 1);
-            aud_playlist_entry_set_selected (list, entry, false);
-            count --;
-        }
-        else
-            i ++;
-    }
+    m_view.update ();
 }
 
 EXPORT void queue_manager_show ()
 {
     dock_show_simple ("queue_manager", _("Queue Manager"),
-                     []() -> QWidget * { return new QueueManager; });
+            []() -> QWidget * { return new QueueManager; });
 }
 
 EXPORT void queue_manager_hide ()


### PR DESCRIPTION
Includes merging Audacious commits# 73acf89 (Support shifting entries) and 1b12ec5 (Fix compiler warning about missing override). fauxd - Also add a [Close] button.  Apparently there were some misc. Audacious visual changes awhile back that we never picked up (as I don't ever use the queue-manager), but the code is now fully up-to-date!